### PR TITLE
Fixed DIDDocument deserialization issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
         "no-constant-condition": "warn",
         "no-class-assign": "warn",
         "require-await": "error",
+        "require-yield": "off",
         "no-async-promise-executor": "error",
         "no-promise-executor-return": "error",
         "no-non-null-assertion": "off",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "secp256r1": "0.0.3",
     "stream-browserify": "^3.0.0",
     "string_decoder": "^1.3.0",
-    "util": "^0.12.3"
+    "util": "^0.12.3",
+    "es-abstract": "1.18.3"
   },
   "devDependencies": {
     "@babel/core": "^7.14.0",

--- a/src/backend/didbiography.ts
+++ b/src/backend/didbiography.ts
@@ -57,13 +57,8 @@ class DIDBiographyStatusDeserializer extends Deserializer {
 @JsonSerialize({using: DIDBiographyStatusSerializer.serialize})
 @JsonDeserialize({using: DIDBiographyStatusDeserializer.deserialize})
 export class DIDBiographyStatus {
-    protected name: string;
-    protected value: number;
 
-    public constructor(value: number, name: string, ) {
-        this.name = name;
-        this.value = value;
-    }
+    public constructor(@JsonProperty({value: 'value'}) private value: number, @JsonProperty({value: 'name'}) private name: string) {}
 
     @JsonValue()
     public getValue(): number {

--- a/src/diddocumentproof.ts
+++ b/src/diddocumentproof.ts
@@ -13,12 +13,12 @@ import { DIDURL, keyTypeFilter } from "./internals";
 /**
  * The Proof represents the proof content of DID Document.
  */
-@JsonPropertyOrder({value: ["type", "created", "creator", "signature"]})
+@JsonPropertyOrder({value: ["type", "created", "creator", "signatureValue"]})
 export class DIDDocumentProof implements Comparable<DIDDocumentProof> {
-    public static TYPE: string = "type";
-    public static CREATOR: string = "creator";
-    public static CREATED: string = "created";
-    public static SIGNATURE_VALUE: string = "signatureValue";
+    public static TYPE = "type";
+    public static CREATOR = "creator";
+    public static CREATED = "created";
+    public static SIGNATURE_VALUE = "signatureValue";
 
     @JsonProperty({ value: DIDDocumentProof.TYPE })
     @JsonInclude({value: JsonIncludeType.CUSTOM, valueFilter: keyTypeFilter})
@@ -33,7 +33,7 @@ export class DIDDocumentProof implements Comparable<DIDDocumentProof> {
     public creator: DIDURL;
     @JsonProperty({ value: DIDDocumentProof.SIGNATURE_VALUE })
     @JsonClassType({type: () => [String]})
-    private signature: string;
+    private signatureValue: string;
 
     /**
      * Constructs the proof of DIDDocument with the given value.
@@ -41,14 +41,10 @@ export class DIDDocumentProof implements Comparable<DIDDocumentProof> {
      * @param type the type of Proof
      * @param created the time to create DIDDocument
      * @param creator the key to sign
-     * @param signature the signature string
+     * @param signatureValue the signature string
      */
     // Java: @JsonCreator
-    constructor(
-        @JsonProperty({value: "creator"}) creator: DIDURL,
-        @JsonProperty({value: "signatureValue"}) signature: string,
-        @JsonProperty({value: "type"}) type?: string,
-        @JsonProperty({value: "created"}) created?: Date) {
+    constructor(creator: DIDURL, signatureValue: string, type?: string, created?: Date) {
         this.type = type ? type : Constants.DEFAULT_PUBLICKEY_TYPE;
 
         if (created === undefined)
@@ -62,7 +58,7 @@ export class DIDDocumentProof implements Comparable<DIDDocumentProof> {
             this.created.setMilliseconds(0);
 
         this.creator = creator;
-        this.signature = signature;
+        this.signatureValue = signatureValue;
     }
 
     equals(obj: DIDDocumentProof): boolean {
@@ -102,7 +98,7 @@ export class DIDDocumentProof implements Comparable<DIDDocumentProof> {
      * @return the signature string
      */
     public getSignature(): string {
-        return this.signature;
+        return this.signatureValue;
     }
 
     public compareTo(proof: DIDDocumentProof): number {

--- a/src/diddocumentpublickeyreference.ts
+++ b/src/diddocumentpublickeyreference.ts
@@ -1,5 +1,5 @@
 import {
-    JsonDeserialize, JsonSerialize
+    JsonDeserialize, JsonSerialize, JsonCreator
 } from "@elastosfoundation/jackson-js";
 import type { Comparable } from "./comparable";
 import type { DIDDocumentPublicKey } from "./internals";
@@ -17,6 +17,11 @@ export class DIDDocumentPublicKeyReference implements Comparable<DIDDocumentPubl
 
     public constructor(id: DIDURL) {
         this.id = id;
+    }
+
+    @JsonCreator()
+    public static jsonConstructor(): DIDDocumentPublicKeyReference {
+        return null;
     }
 
     static newWithURL(id: DIDURL): DIDDocumentPublicKeyReference {

--- a/src/didurl.ts
+++ b/src/didurl.ts
@@ -124,7 +124,7 @@ export class DIDURL implements Hashable, Comparable<DIDURL> {
 
                 try {
                     let urlParsed = DIDURLParser.newFromURL(url);
-
+                    
                     if (urlParsed.did.isEmpty)
                         this.did = baseRef ? baseRef : null;
                     else

--- a/src/verificationEventListener.ts
+++ b/src/verificationEventListener.ts
@@ -21,9 +21,9 @@
  */
         
 export class VerificationEventListener {
-    public done(context : Object, succeeded : boolean, message : string) : void {};
+    public done(context : Object, succeeded : boolean, message : string) : void {}
 
-    public reset() : void {};
+    public reset() : void {}
 
     private eprintf(format : string, args : Object[]) : string {
         let content = String(format);


### PR DESCRIPTION
Fixed few deserialization errors on DIDDocumentProof and DIDDocumentPublicKey while processing a DIDDocument payload.

TODO : Custom serializers on DIDDocument.controllers and DIDDocument._proofs have been removed. There were used to return an instance instead of an array when it contains only one element. We'll have to check later if this feature was really mandatory.